### PR TITLE
feat: ignore elements with a vite-ignore or wxt-ignore attribute

### DIFF
--- a/packages/wxt/src/core/builders/vite/plugins/devHtmlPrerender.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/devHtmlPrerender.ts
@@ -150,6 +150,10 @@ export function pointToDevServer(
   attr: string,
 ) {
   document.querySelectorAll(querySelector).forEach((element) => {
+    if (element.hasAttribute('vite-ignore') || element.hasAttribute('wxt-ignore')) {
+      element.removeAttribute('wxt-ignore');
+      return;
+    }
     const src = element.getAttribute(attr);
     if (!src || isUrl(src)) return;
 


### PR DESCRIPTION
### Overview

This PR adds the ability for the user to use ignore attributes, either `vite-ignore` or `wxt-ignore` in html elements to make wxt ignore those elements and not process the src or href attributes.
If `wxt-ignore` is used as attribute, the attribute is removed. The `vite-ignore` attribute does not need to be removed as it is removed later by Vite.

### Manual Testing

Add the attribute `vite-ignore` or `wxt-ignore` to a `link` element in an entrypoint html file. The `href` attribute should not be processed in the resulting html file and the `vite-ignore` or `wxt-ignore` should be removed.

### Related Issue

N/A.
The problem was discussed here: #1548


